### PR TITLE
Refine popup spacing and layout

### DIFF
--- a/src/main/java/com/pathmind/ui/NodeParameterOverlay.java
+++ b/src/main/java/com/pathmind/ui/NodeParameterOverlay.java
@@ -553,10 +553,23 @@ public class NodeParameterOverlay {
     private int computeButtonY() {
         int offset = CONTENT_START_OFFSET;
         if (hasModeSelection()) {
-            offset += LABEL_TO_FIELD_OFFSET + FIELD_HEIGHT + SECTION_SPACING;
+            offset += LABEL_TO_FIELD_OFFSET + FIELD_HEIGHT;
+            if (!node.getParameters().isEmpty()) {
+                offset += SECTION_SPACING;
+            }
         }
-        offset += node.getParameters().size() * (LABEL_TO_FIELD_OFFSET + FIELD_HEIGHT + SECTION_SPACING);
-        return popupY + offset + BUTTON_TOP_MARGIN;
+
+        int paramCount = node.getParameters().size();
+        for (int i = 0; i < paramCount; i++) {
+            offset += LABEL_TO_FIELD_OFFSET + FIELD_HEIGHT;
+            if (i < paramCount - 1) {
+                offset += SECTION_SPACING;
+            }
+        }
+
+        int contentDrivenY = popupY + offset + BUTTON_TOP_MARGIN;
+        int bottomAlignedY = popupY + popupHeight - (BOTTOM_PADDING + BUTTON_HEIGHT);
+        return Math.max(contentDrivenY, bottomAlignedY);
     }
     
     private int adjustColorBrightness(int color, float factor) {


### PR DESCRIPTION
## Summary
- compute popup dimensions dynamically for the clear and import/export dialogs to eliminate excess blank space
- reuse the calculated layout metrics for hover/click handling via dedicated layout helper classes
- keep node parameter overlay buttons away from the popup edge by aligning them with the configured bottom padding

## Testing
- ./gradlew check *(fails: Baritone API jar not found)*

------
https://chatgpt.com/codex/tasks/task_e_68f40b32a30883298813a2ac3678fa84