### PR TITLE
Fix Pathmind keybind localization and default mapping

### DIFF
--- a/bin/main/assets/pathmind/lang/en_us.json
+++ b/bin/main/assets/pathmind/lang/en_us.json
@@ -1,5 +1,6 @@
 {
   "key.pathmind.open_visual_editor": "Open Pathmind Visual Editor",
+  "key.pathmind.play_last_graph": "Play Last Pathmind Graph",
   "category.pathmind.general": "Pathmind",
   "screen.pathmind.visual_editor.title": "Pathmind Visual Editor",
   "screen.pathmind.visual_editor.subtitle": "Create and manage node-based workflows",

--- a/bin/main/assets/pathmind/lang/es_es.json
+++ b/bin/main/assets/pathmind/lang/es_es.json
@@ -1,5 +1,6 @@
 {
   "key.pathmind.open_visual_editor": "Abrir Editor Visual Pathmind",
+  "key.pathmind.play_last_graph": "Reproducir Último Gráfico de Pathmind",
   "category.pathmind.general": "Pathmind",
   "screen.pathmind.visual_editor.title": "Editor Visual Pathmind",
   "screen.pathmind.visual_editor.subtitle": "Crear y gestionar flujos de trabajo basados en nodos",

--- a/src/main/java/com/pathmind/PathmindKeybinds.java
+++ b/src/main/java/com/pathmind/PathmindKeybinds.java
@@ -21,7 +21,7 @@ public class PathmindKeybinds {
         PLAY_LAST_GRAPH = new KeyBinding(
                 "key.pathmind.play_last_graph",
                 InputUtil.Type.KEYSYM,
-                GLFW.GLFW_KEY_P,
+                GLFW.GLFW_KEY_K,
                 "category.pathmind.general"
         );
     }

--- a/src/main/resources/assets/pathmind/lang/en_us.json
+++ b/src/main/resources/assets/pathmind/lang/en_us.json
@@ -1,5 +1,6 @@
 {
   "key.pathmind.open_visual_editor": "Open Pathmind Visual Editor",
+  "key.pathmind.play_last_graph": "Play Last Pathmind Graph",
   "category.pathmind.general": "Pathmind",
   "screen.pathmind.visual_editor.title": "Pathmind Visual Editor",
   "screen.pathmind.visual_editor.subtitle": "Create and manage node-based workflows",

--- a/src/main/resources/assets/pathmind/lang/es_es.json
+++ b/src/main/resources/assets/pathmind/lang/es_es.json
@@ -1,5 +1,6 @@
 {
   "key.pathmind.open_visual_editor": "Abrir Editor Visual Pathmind",
+  "key.pathmind.play_last_graph": "Reproducir Último Gráfico de Pathmind",
   "category.pathmind.general": "Pathmind",
   "screen.pathmind.visual_editor.title": "Editor Visual Pathmind",
   "screen.pathmind.visual_editor.subtitle": "Crear y gestionar flujos de trabajo basados en nodos",


### PR DESCRIPTION
## Summary
- add localized labels for the Pathmind "Play Last Graph" key binding
- switch the default binding to K to avoid conflicting with Minecraft's default controls

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f44f0a3c148329aca96887f5db4b73