### PR TITLE
Fix main menu button icon rendering

### DIFF
--- a/src/main/java/com/pathmind/screen/PathmindMainMenuButton.java
+++ b/src/main/java/com/pathmind/screen/PathmindMainMenuButton.java
@@ -22,7 +22,10 @@ public class PathmindMainMenuButton extends ButtonWidget {
 
     @Override
     protected void renderWidget(DrawContext context, int mouseX, int mouseY, float delta) {
+        Text originalMessage = this.getMessage();
+        this.setMessage(Text.empty());
         super.renderWidget(context, mouseX, mouseY, delta);
+        this.setMessage(originalMessage);
 
         int iconSize = this.width - ICON_PADDING * 2;
         int iconX = this.getX() + ICON_PADDING;


### PR DESCRIPTION
## Summary
- render the Pathmind main menu button icon using DrawContext#drawTexture so the icon uses the 128x128 icon asset without distortion

## Testing
- ./gradlew build

------
https://chatgpt.com/codex/tasks/task_e_68f540175a24832983f319110c31664a