### PR TITLE
Fix menu icon texture reference

### DIFF
--- a/bin/main/fabric.mod.json
+++ b/bin/main/fabric.mod.json
@@ -13,7 +13,7 @@
     "issues": "https://github.com/yourusername/pathmind/issues"
   },
   "license": "CC BY-NC 4.0",
-  "icon": "assets/pathmind/icon.png",
+  "icon": "assets/pathmind/logo.png",
   "environment": "*",
   "entrypoints": {
     "main": [

--- a/fabric.mod.json
+++ b/fabric.mod.json
@@ -14,7 +14,7 @@
     "issues": "https://github.com/cabaletta/baritone/issues"
   },
   "license": "LGPL-3.0",
-  "icon": "assets/baritone/icon.png",
+  "icon": "assets/pathmind/logo.png",
   "environment": "*",
   "entrypoints": {},
   "mixins": [

--- a/src/main/java/com/pathmind/screen/PathmindMainMenuButton.java
+++ b/src/main/java/com/pathmind/screen/PathmindMainMenuButton.java
@@ -12,7 +12,7 @@ import net.minecraft.util.Identifier;
  * A small icon button used on the title screen to open the Pathmind visual editor.
  */
 public class PathmindMainMenuButton extends ButtonWidget {
-    private static final Identifier ICON_TEXTURE = PathmindMod.id("icon.png");
+    private static final Identifier ICON_TEXTURE = PathmindMod.id("logo.png");
     private static final int ICON_PADDING = 2;
 
     public PathmindMainMenuButton(int x, int y, int size, PressAction pressAction) {

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -13,7 +13,7 @@
     "issues": "https://github.com/yourusername/pathmind/issues"
   },
   "license": "CC BY-NC 4.0",
-  "icon": "assets/pathmind/icon.png",
+  "icon": "assets/pathmind/logo.png",
   "environment": "*",
   "entrypoints": {
     "main": [


### PR DESCRIPTION
## Summary
- update mod metadata to reference the bundled logo texture
- point the main menu button to the shared logo asset to avoid missing textures

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f5687549588329a054279618d97cb9