### PR TITLE
Expand parameter node palette with reusable string inputs

### DIFF
--- a/src/main/java/com/pathmind/data/NodeGraphData.java
+++ b/src/main/java/com/pathmind/data/NodeGraphData.java
@@ -141,23 +141,30 @@ public class NodeGraphData {
         private String name;
         private String value;
         private String type;
-        
-        public ParameterData() {}
-        
+        private String attachedNodeId;
+
+        public ParameterData() {
+            this.attachedNodeId = null;
+        }
+
         public ParameterData(String name, String value, String type) {
             this.name = name;
             this.value = value;
             this.type = type;
+            this.attachedNodeId = null;
         }
-        
+
         // Getters and setters
         public String getName() { return name; }
         public void setName(String name) { this.name = name; }
-        
+
         public String getValue() { return value; }
         public void setValue(String value) { this.value = value; }
-        
+
         public String getType() { return type; }
         public void setType(String type) { this.type = type; }
+
+        public String getAttachedNodeId() { return attachedNodeId; }
+        public void setAttachedNodeId(String attachedNodeId) { this.attachedNodeId = attachedNodeId; }
     }
 }

--- a/src/main/java/com/pathmind/data/NodeGraphPersistence.java
+++ b/src/main/java/com/pathmind/data/NodeGraphPersistence.java
@@ -55,8 +55,9 @@ public class NodeGraphPersistence {
                 for (NodeParameter param : node.getParameters()) {
                     NodeGraphData.ParameterData paramData = new NodeGraphData.ParameterData();
                     paramData.setName(param.getName());
-                    paramData.setValue(param.getStringValue());
+                    paramData.setValue(param.getStoredStringValue());
                     paramData.setType(param.getType().name());
+                    paramData.setAttachedNodeId(param.getAttachedParameterNodeId());
                     paramDataList.add(paramData);
                 }
                 nodeData.setParameters(paramDataList);
@@ -161,6 +162,7 @@ public class NodeGraphPersistence {
                 for (NodeGraphData.ParameterData paramData : nodeData.getParameters()) {
                     ParameterType paramType = ParameterType.valueOf(paramData.getType());
                     NodeParameter param = new NodeParameter(paramData.getName(), paramType, paramData.getValue());
+                    param.setAttachedParameterNodeId(paramData.getAttachedNodeId());
                     node.getParameters().add(param);
                 }
             }
@@ -206,6 +208,23 @@ public class NodeGraphPersistence {
                 Node control = nodeMap.get(nodeData.getParentActionControlId());
                 if (child != null && control != null && control.canAcceptActionNode(child)) {
                     control.attachActionNode(child);
+                }
+            }
+        }
+
+        for (NodeGraphData.NodeData nodeData : data.getNodes()) {
+            Node node = nodeMap.get(nodeData.getId());
+            if (node == null) {
+                continue;
+            }
+            for (NodeParameter parameter : node.getParameters()) {
+                String attachedId = parameter.getAttachedParameterNodeId();
+                if (attachedId == null) {
+                    continue;
+                }
+                Node attachedNode = nodeMap.get(attachedId);
+                if (attachedNode != null) {
+                    node.attachParameterNode(attachedNode, parameter);
                 }
             }
         }

--- a/src/main/java/com/pathmind/nodes/NodeCategory.java
+++ b/src/main/java/com/pathmind/nodes/NodeCategory.java
@@ -11,7 +11,8 @@ public enum NodeCategory {
     INTERACTION("Interaction", 0xFF7E57C2, "Combat and interaction commands", "✋"),
     INVENTORY("Inventory", 0xFF8D6E63, "Inventory and equipment management", "🎒"),
     SENSORS("Sensors", 0xFF64B5F6, "Environment and state checks", "📡"),
-    UTILITY("Utility", 0xFF9E9E9E, "Utility and messaging tools", "⚙");
+    UTILITY("Utility", 0xFF9E9E9E, "Utility and messaging tools", "⚙"),
+    PARAMETERS("Parameters", 0xFF5E35B1, "Reusable parameter nodes", "⌘");
 
     private final String displayName;
     private final int color;

--- a/src/main/java/com/pathmind/nodes/NodeParameter.java
+++ b/src/main/java/com/pathmind/nodes/NodeParameter.java
@@ -1,5 +1,7 @@
 package com.pathmind.nodes;
 
+import java.util.OptionalDouble;
+
 /**
  * Represents a parameter for a node in the Pathmind visual editor.
  * Each parameter has a name, value, and type.
@@ -11,6 +13,8 @@ public class NodeParameter {
     private int intValue;
     private double doubleValue;
     private boolean boolValue;
+    private Node attachedParameterNode;
+    private String attachedParameterNodeId;
 
     public NodeParameter(String name, ParameterType type, String defaultValue) {
         this.name = name;
@@ -19,6 +23,8 @@ public class NodeParameter {
         this.intValue = 0;
         this.doubleValue = 0.0;
         this.boolValue = false;
+        this.attachedParameterNode = null;
+        this.attachedParameterNodeId = null;
         
         // Try to parse the default value based on type
         if (type == ParameterType.INTEGER) {
@@ -47,6 +53,95 @@ public class NodeParameter {
     }
 
     public String getStringValue() {
+        if (attachedParameterNode != null) {
+            NodeType attachedType = attachedParameterNode.getType();
+            switch (attachedType) {
+                case PARAM_BLOCK_TYPE: {
+                    NodeParameter blockParam = attachedParameterNode.getParameter("Block");
+                    if (blockParam != null) {
+                        return blockParam.getStringValue();
+                    }
+                    break;
+                }
+                case PARAM_ITEM_STACK: {
+                    NodeParameter itemParam = attachedParameterNode.getParameter("Item");
+                    if (itemParam != null) {
+                        return itemParam.getStringValue();
+                    }
+                    break;
+                }
+                case PARAM_NUMBER: {
+                    NodeParameter valueParam = attachedParameterNode.getParameter("Value");
+                    if (valueParam != null) {
+                        return valueParam.getDisplayValue();
+                    }
+                    break;
+                }
+                case PARAM_BOOLEAN: {
+                    NodeParameter valueParam = attachedParameterNode.getParameter("Value");
+                    if (valueParam != null) {
+                        return Boolean.toString(valueParam.getBoolValue());
+                    }
+                    break;
+                }
+                case PARAM_STRING: {
+                    NodeParameter valueParam = attachedParameterNode.getParameter("Value");
+                    if (valueParam != null) {
+                        return valueParam.getStringValue();
+                    }
+                    break;
+                }
+                case PARAM_PLAYER_NAME: {
+                    NodeParameter valueParam = attachedParameterNode.getParameter("Player");
+                    if (valueParam != null) {
+                        return valueParam.getStringValue();
+                    }
+                    break;
+                }
+                case PARAM_ENTITY_TYPE: {
+                    NodeParameter valueParam = attachedParameterNode.getParameter("Entity");
+                    if (valueParam != null) {
+                        return valueParam.getStringValue();
+                    }
+                    break;
+                }
+                case PARAM_WAYPOINT_NAME: {
+                    NodeParameter valueParam = attachedParameterNode.getParameter("Waypoint");
+                    if (valueParam != null) {
+                        return valueParam.getStringValue();
+                    }
+                    break;
+                }
+                case PARAM_WAYPOINT_TAG: {
+                    NodeParameter valueParam = attachedParameterNode.getParameter("Tag");
+                    if (valueParam != null) {
+                        return valueParam.getStringValue();
+                    }
+                    break;
+                }
+                case PARAM_SCHEMATIC: {
+                    NodeParameter valueParam = attachedParameterNode.getParameter("Schematic");
+                    if (valueParam != null) {
+                        return valueParam.getStringValue();
+                    }
+                    break;
+                }
+                case PARAM_COORDINATE:
+                case PARAM_ITEM_LOCATION: {
+                    OptionalDouble component = attachedParameterNode.resolveCoordinateComponent(name);
+                    if (component.isPresent()) {
+                        double value = component.getAsDouble();
+                        if (Math.abs(value - Math.rint(value)) < 1e-6) {
+                            return Integer.toString((int) Math.round(value));
+                        }
+                        return Double.toString(value);
+                    }
+                    break;
+                }
+                default:
+                    break;
+            }
+        }
         return stringValue;
     }
 
@@ -72,6 +167,35 @@ public class NodeParameter {
     }
 
     public int getIntValue() {
+        if (attachedParameterNode != null) {
+            NodeType attachedType = attachedParameterNode.getType();
+            switch (attachedType) {
+                case PARAM_COORDINATE:
+                case PARAM_ITEM_LOCATION: {
+                    OptionalDouble component = attachedParameterNode.resolveCoordinateComponent(name);
+                    if (component.isPresent()) {
+                        return (int) Math.round(component.getAsDouble());
+                    }
+                    break;
+                }
+                case PARAM_NUMBER: {
+                    NodeParameter valueParam = attachedParameterNode.getParameter("Value");
+                    if (valueParam != null) {
+                        return (int) Math.round(valueParam.getDoubleValue());
+                    }
+                    break;
+                }
+                case PARAM_BOOLEAN: {
+                    NodeParameter valueParam = attachedParameterNode.getParameter("Value");
+                    if (valueParam != null) {
+                        return valueParam.getBoolValue() ? 1 : 0;
+                    }
+                    break;
+                }
+                default:
+                    break;
+            }
+        }
         return intValue;
     }
 
@@ -81,6 +205,35 @@ public class NodeParameter {
     }
 
     public double getDoubleValue() {
+        if (attachedParameterNode != null) {
+            NodeType attachedType = attachedParameterNode.getType();
+            switch (attachedType) {
+                case PARAM_COORDINATE:
+                case PARAM_ITEM_LOCATION: {
+                    OptionalDouble component = attachedParameterNode.resolveCoordinateComponent(name);
+                    if (component.isPresent()) {
+                        return component.getAsDouble();
+                    }
+                    break;
+                }
+                case PARAM_NUMBER: {
+                    NodeParameter valueParam = attachedParameterNode.getParameter("Value");
+                    if (valueParam != null) {
+                        return valueParam.getDoubleValue();
+                    }
+                    break;
+                }
+                case PARAM_BOOLEAN: {
+                    NodeParameter valueParam = attachedParameterNode.getParameter("Value");
+                    if (valueParam != null) {
+                        return valueParam.getBoolValue() ? 1.0 : 0.0;
+                    }
+                    break;
+                }
+                default:
+                    break;
+            }
+        }
         return doubleValue;
     }
 
@@ -90,12 +243,71 @@ public class NodeParameter {
     }
 
     public boolean getBoolValue() {
+        if (attachedParameterNode != null) {
+            NodeType attachedType = attachedParameterNode.getType();
+            switch (attachedType) {
+                case PARAM_BOOLEAN: {
+                    NodeParameter valueParam = attachedParameterNode.getParameter("Value");
+                    if (valueParam != null) {
+                        return valueParam.getBoolValue();
+                    }
+                    break;
+                }
+                case PARAM_NUMBER: {
+                    NodeParameter valueParam = attachedParameterNode.getParameter("Value");
+                    if (valueParam != null) {
+                        return valueParam.getDoubleValue() != 0.0;
+                    }
+                    break;
+                }
+                default:
+                    break;
+            }
+        }
         return boolValue;
     }
 
     public void setBoolValue(boolean value) {
         this.boolValue = value;
         this.stringValue = String.valueOf(value);
+    }
+
+    public boolean hasAttachedParameterNode() {
+        return attachedParameterNode != null;
+    }
+
+    public void attachParameterNode(Node node) {
+        this.attachedParameterNode = node;
+        this.attachedParameterNodeId = node != null ? node.getId() : null;
+    }
+
+    public void detachParameterNode() {
+        if (attachedParameterNode != null) {
+            attachedParameterNode.clearParameterParentAttachment();
+        }
+        this.attachedParameterNode = null;
+        this.attachedParameterNodeId = null;
+    }
+
+    public Node getAttachedParameterNode() {
+        return attachedParameterNode;
+    }
+
+    public String getAttachedParameterNodeId() {
+        return attachedParameterNodeId;
+    }
+
+    public void setAttachedParameterNodeId(String nodeId) {
+        this.attachedParameterNodeId = nodeId;
+    }
+
+    public void setAttachedParameterNode(Node node) {
+        this.attachedParameterNode = node;
+        this.attachedParameterNodeId = node != null ? node.getId() : null;
+    }
+
+    public String getStoredStringValue() {
+        return stringValue;
     }
 
     public String getDisplayValue() {

--- a/src/main/java/com/pathmind/nodes/NodeType.java
+++ b/src/main/java/com/pathmind/nodes/NodeType.java
@@ -91,14 +91,34 @@ public enum NodeType {
     // Utility Commands
     SCREEN_CONTROL("Screen Control", 0xFF9E9E9E, "Open or close in-game screens"),
     WAIT("Wait", 0xFF607D8B, "Waits for specified duration"),
-    MESSAGE("Message", 0xFF9E9E9E, "Sends a chat message");
+    MESSAGE("Message", 0xFF9E9E9E, "Sends a chat message"),
+
+    // Parameter nodes
+    PARAM_COORDINATE("Coordinate", 0xFF5E35B1, "Provides an XYZ coordinate parameter", ParameterType.COORDINATE),
+    PARAM_ITEM_LOCATION("Item Location", 0xFF5E35B1, "Finds the location of a dropped item", ParameterType.COORDINATE),
+    PARAM_BLOCK_TYPE("Block Parameter", 0xFF5E35B1, "Defines a reusable block type", ParameterType.BLOCK_TYPE),
+    PARAM_ITEM_STACK("Item Parameter", 0xFF5E35B1, "Defines a reusable item identifier", ParameterType.ITEM),
+    PARAM_NUMBER("Number", 0xFF5E35B1, "Reusable numeric value", ParameterType.DOUBLE),
+    PARAM_BOOLEAN("Boolean", 0xFF5E35B1, "Reusable true/false flag", ParameterType.BOOLEAN),
+    PARAM_STRING("Text", 0xFF5E35B1, "Reusable string literal", ParameterType.STRING),
+    PARAM_PLAYER_NAME("Player", 0xFF5E35B1, "Reusable player selector", ParameterType.PLAYER_NAME),
+    PARAM_ENTITY_TYPE("Entity", 0xFF5E35B1, "Reusable entity identifier", ParameterType.ENTITY_TYPE),
+    PARAM_WAYPOINT_NAME("Waypoint", 0xFF5E35B1, "Reusable waypoint name", ParameterType.WAYPOINT_NAME),
+    PARAM_WAYPOINT_TAG("Waypoint Tag", 0xFF5E35B1, "Reusable waypoint tag", ParameterType.WAYPOINT_TAG),
+    PARAM_SCHEMATIC("Schematic", 0xFF5E35B1, "Reusable schematic path", ParameterType.SCHEMATIC);
 
     private final String displayName;
     private final String description;
+    private final ParameterType providedParameterType;
 
     NodeType(String displayName, int color, String description) {
+        this(displayName, color, description, null);
+    }
+
+    NodeType(String displayName, int color, String description, ParameterType providedParameterType) {
         this.displayName = displayName;
         this.description = description;
+        this.providedParameterType = providedParameterType;
     }
 
     public String getDisplayName() {
@@ -128,12 +148,33 @@ public enum NodeType {
     public boolean isDraggableFromSidebar() {
         return true; // All nodes including START can be dragged from sidebar
     }
-    
+
+    public boolean isParameterNode() {
+        return getCategory() == NodeCategory.PARAMETERS;
+    }
+
+    public ParameterType getProvidedParameterType() {
+        return providedParameterType;
+    }
+
     /**
      * Get the category this node belongs to for sidebar organization
      */
     public NodeCategory getCategory() {
         switch (this) {
+            case PARAM_COORDINATE:
+            case PARAM_ITEM_LOCATION:
+            case PARAM_BLOCK_TYPE:
+            case PARAM_ITEM_STACK:
+            case PARAM_NUMBER:
+            case PARAM_BOOLEAN:
+            case PARAM_STRING:
+            case PARAM_PLAYER_NAME:
+            case PARAM_ENTITY_TYPE:
+            case PARAM_WAYPOINT_NAME:
+            case PARAM_WAYPOINT_TAG:
+            case PARAM_SCHEMATIC:
+                return NodeCategory.PARAMETERS;
             case START:
             case EVENT_FUNCTION:
             case EVENT_CALL:
@@ -262,6 +303,12 @@ public enum NodeType {
             case SENSOR_ENTITY_NEARBY:
             case SENSOR_ITEM_IN_INVENTORY:
             case SENSOR_IS_FALLING:
+            case PARAM_COORDINATE:
+            case PARAM_ITEM_LOCATION:
+            case PARAM_BLOCK_TYPE:
+            case PARAM_ITEM_STACK:
+            case PARAM_NUMBER:
+            case PARAM_BOOLEAN:
                 return true;
             default:
                 return false;

--- a/src/main/java/com/pathmind/nodes/ParameterType.java
+++ b/src/main/java/com/pathmind/nodes/ParameterType.java
@@ -10,6 +10,7 @@ public enum ParameterType {
     BOOLEAN("Boolean"),
     COORDINATE("Coordinate"),
     BLOCK_TYPE("Block Type"),
+    ITEM("Item"),
     PLAYER_NAME("Player Name"),
     ENTITY_TYPE("Entity Type"),
     SCHEMATIC("Schematic"),


### PR DESCRIPTION
## Summary
- add parameter node types for reusable text, player, entity, waypoint, and schematic parameters
- initialize the new parameter nodes with appropriate default fields and defaults
- teach parameter slots to forward string values from the new parameter nodes

## Testing
- ./gradlew build

------
https://chatgpt.com/codex/tasks/task_e_68f5a6fab9b4832981d79b87a6c00bf9