### PR TITLE
Add coordinate slot and nearest-open-block parameter to Place node

### DIFF
--- a/src/main/java/com/pathmind/data/NodeGraphData.java
+++ b/src/main/java/com/pathmind/data/NodeGraphData.java
@@ -53,7 +53,9 @@ public class NodeGraphData {
         private String attachedActionId;
         private String parentActionControlId;
         private String attachedParameterId;
+        private String attachedSecondaryParameterId;
         private String parentParameterHostId;
+        private String parameterAttachmentSlot;
 
         public NodeData() {
             this.parameters = new ArrayList<>();
@@ -71,7 +73,9 @@ public class NodeGraphData {
             this.attachedActionId = null;
             this.parentActionControlId = null;
             this.attachedParameterId = null;
+            this.attachedSecondaryParameterId = null;
             this.parentParameterHostId = null;
+            this.parameterAttachmentSlot = null;
         }
 
         // Getters and setters
@@ -108,8 +112,14 @@ public class NodeGraphData {
         public String getAttachedParameterId() { return attachedParameterId; }
         public void setAttachedParameterId(String attachedParameterId) { this.attachedParameterId = attachedParameterId; }
 
+        public String getAttachedSecondaryParameterId() { return attachedSecondaryParameterId; }
+        public void setAttachedSecondaryParameterId(String attachedSecondaryParameterId) { this.attachedSecondaryParameterId = attachedSecondaryParameterId; }
+
         public String getParentParameterHostId() { return parentParameterHostId; }
         public void setParentParameterHostId(String parentParameterHostId) { this.parentParameterHostId = parentParameterHostId; }
+
+        public String getParameterAttachmentSlot() { return parameterAttachmentSlot; }
+        public void setParameterAttachmentSlot(String parameterAttachmentSlot) { this.parameterAttachmentSlot = parameterAttachmentSlot; }
     }
     
     /**

--- a/src/main/java/com/pathmind/nodes/NodeType.java
+++ b/src/main/java/com/pathmind/nodes/NodeType.java
@@ -111,6 +111,7 @@ public enum NodeType {
     PARAM_RANGE("Range", 0xFF8BC34A, "Represents a generic radius or range"),
     PARAM_ROTATION("Rotation", 0xFF8BC34A, "Represents yaw and pitch angles"),
     PARAM_PLACE_TARGET("Place", 0xFF8BC34A, "Represents a block placement with coordinates"),
+    PARAM_NEAREST_OPEN_BLOCK("Nearest Open Block", 0xFF8BC34A, "Finds the nearest open block location"),
     PARAM_LIGHT_THRESHOLD("Light Threshold", 0xFF8BC34A, "Represents a light level threshold"),
     PARAM_HEALTH_THRESHOLD("Health Threshold", 0xFF8BC34A, "Represents a health threshold"),
     PARAM_HUNGER_THRESHOLD("Hunger Threshold", 0xFF8BC34A, "Represents a hunger threshold"),


### PR DESCRIPTION
## Summary
- add a Nearest Open Block parameter type and expose a second parameter slot on the Place node so block and coordinate inputs can be attached simultaneously
- update runtime, serialization, and UI handling to merge parameter data, look up the nearest open placement location, and persist the new slot metadata

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68f97be8c928832994b5b61cc453c03f