### PR TITLE
Fix collect command dispatch thread handling

### DIFF
--- a/src/main/java/com/pathmind/nodes/Node.java
+++ b/src/main/java/com/pathmind/nodes/Node.java
@@ -3381,12 +3381,19 @@ public class Node {
                     return;
                 }
 
-                client.execute(() -> {
+                if (client != null) {
+                    client.execute(() -> {
+                        startCollectCompletionWatcher(baritone, finalMineProcess, future);
+                        if (finalTrackAmount) {
+                            startCollectAmountMonitor(baritone, finalMineProcess, finalTrackedItem, finalStartingCount, finalRequestedAmount, future);
+                        }
+                    });
+                } else {
                     startCollectCompletionWatcher(baritone, finalMineProcess, future);
                     if (finalTrackAmount) {
                         startCollectAmountMonitor(baritone, finalMineProcess, finalTrackedItem, finalStartingCount, finalRequestedAmount, future);
                     }
-                });
+                }
             });
     }
 


### PR DESCRIPTION
## Summary
- dispatch Baritone collect commands on the Minecraft client thread when available
- fall back to background execution only when the client instance is unavailable while preserving existing error handling

## Testing
- ./gradlew build

------
https://chatgpt.com/codex/tasks/task_e_68f9beecf39c832992825605637b4942