### PR TITLE
Remove sockets from parameter nodes

### DIFF
--- a/src/main/java/com/pathmind/nodes/Node.java
+++ b/src/main/java/com/pathmind/nodes/Node.java
@@ -573,14 +573,14 @@ public class Node {
     }
 
     public int getInputSocketCount() {
-        if (type == NodeType.START || type == NodeType.EVENT_FUNCTION || isSensorNode()) {
+        if (type == NodeType.START || type == NodeType.EVENT_FUNCTION || isSensorNode() || isParameterNode()) {
             return 0;
         }
         return 1;
     }
 
     public int getOutputSocketCount() {
-        if (isSensorNode()) {
+        if (isSensorNode() || isParameterNode()) {
             return 0;
         }
         if (type == NodeType.CONTROL_FOREVER) {


### PR DESCRIPTION
## Summary
- stop parameter node types from reporting any input sockets
- prevent parameter node types from reporting output sockets to hide the connection points

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_68fa84b54b2c83298eaba4d790d89234