### PR TITLE
[Bugfix] Add Return text

### DIFF
--- a/src/main/resources/assets/pathmind/lang/en_us.json
+++ b/src/main/resources/assets/pathmind/lang/en_us.json
@@ -151,9 +151,11 @@
   "pathmind.node.type.controlForever": "Forever",
   "pathmind.node.type.controlForever.desc": "Loop enclosed nodes indefinitely",
   "pathmind.node.type.controlIf": "If",
+  "pathmind.node.type.return": "Return",
   "pathmind.node.type.controlIf.desc": "Run the next branch only when a condition is true",
   "pathmind.node.type.controlIfElse": "If Else",
   "pathmind.node.type.controlIfElse.desc": "Run one of two branches depending on a condition",
+  "pathmind.node.type.return.desc": "Stops current function",
 
   "pathmind.node.type.look": "Look",
   "pathmind.node.type.look.desc": "Adjusts the player's view direction",


### PR DESCRIPTION
The text for the Return node is currently left as it's translation-index; this pull-request adds those texts to ``en_us.lang``.
<img width="3840" height="2160" alt="image" src="https://github.com/user-attachments/assets/ba75f553-3adc-42f8-91a4-dc80a0ffd7a3" />