### PR TITLE
INTERACT: honor the inline Block parameter like COLLECT/PLACE do

### DIFF
--- a/common/src/main/java/com/pathmind/nodes/NodeEntityActionCommandExecutor.java
+++ b/common/src/main/java/com/pathmind/nodes/NodeEntityActionCommandExecutor.java
@@ -101,14 +101,27 @@ final class NodeEntityActionCommandExecutor {
         Node attachedParameter = preprocessParameter != null ? preprocessParameter : owner.getAttachedParameter(0);
         ActionResult result;
 
-        if (attachedParameter != null && attachedParameter.getType() == NodeType.PARAM_BLOCK) {
-            String blockSelectionRaw = owner.getBlockParameterValue(attachedParameter);
+        boolean hasAttachedBlockParameter = attachedParameter != null && attachedParameter.getType() == NodeType.PARAM_BLOCK;
+        String blockSelectionRaw = null;
+        if (hasAttachedBlockParameter) {
+            blockSelectionRaw = owner.getBlockParameterValue(attachedParameter);
             if (blockSelectionRaw == null || blockSelectionRaw.isBlank()) {
                 restoreSneakState.run();
                 owner.sendNodeErrorMessage(client, tr("pathmind.error.interactUnknownBlock", "block"));
                 future.complete(null);
                 return;
             }
+        } else {
+            // Inline "Block" parameter fallback — the same two-source pattern COLLECT and
+            // PLACE use: an attached parameter node wins, otherwise the node's own Block
+            // field selects the target. Blank keeps the entity/crosshair behavior.
+            String inlineBlockSelection = owner.getStringParameter("Block", null);
+            if (inlineBlockSelection != null && !inlineBlockSelection.isBlank()) {
+                blockSelectionRaw = inlineBlockSelection;
+            }
+        }
+
+        if (blockSelectionRaw != null) {
             Optional<BlockSelection> blockSelection = BlockSelection.parse(blockSelectionRaw);
             if (blockSelection.isEmpty()) {
                 restoreSneakState.run();


### PR DESCRIPTION
## What

The INTERACT node registers a `Block` parameter (it shows up as an editable field on the node in the editor), but the executor never reads it: block targeting only works through a graph-attached PARAM_BLOCK node, and otherwise the node falls back to whatever the crosshair happens to point at. The inline field is silently dead.

This PR makes INTERACT follow the same two-source pattern COLLECT and PLACE already use:

1. an attached parameter node wins (unchanged), and
2. when no parameter node is attached and the inline `Block` field is set, the same nearest-reachable-block targeting path is used (`findNearestReachableBlock` + computed `BlockHitResult`, independent of the crosshair).

A blank `Block` field keeps the exact previous entity/crosshair behavior, so existing graphs are unaffected.

## Why

Found while driving INTERACT programmatically (crafting-table workflow): aiming at a block center and clicking via the crosshair is unreliable — the raycast can clip a neighboring block (in our repro, the oak log next to the table) and the interaction silently opens nothing. The computed-hit path INTERACT already has for attached parameter nodes solves this deterministically; it just wasn't reachable via the inline field, even though the editor displays one.

## Scope

- 15 insertions, 2 deletions in `NodeEntityActionCommandExecutor.executeInteractCommand`
- No behavior change for any node with a blank Block field
- Verified: `:common:build` green on this branch; end-to-end verified in a dev client (crafting-table open via `Block=crafting_table` works where the crosshair path failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)